### PR TITLE
Correct/Incorrect Highlights

### DIFF
--- a/server/static/scripts/script.js
+++ b/server/static/scripts/script.js
@@ -140,9 +140,9 @@ $( document ).ready(function() {
           var message = "<button id=continueButton class=\"btn btn-default\">";
           message += "Continue</button>";
           if (guess === data["label"]) {
-            message += "<p>You were correct.</p>";
+            message += "<p>You were <span class='correct'>correct</span>.</p>";
           } else {
-            message += "<p>You were incorrect.</p>";
+            message += "<p>You were <span class='incorrect'>incorrect</span>.</p>";
           }
           message += "<p>Your guess: "+guess+"</p>";
           message += "<p>Correct answer: "+data["label"]+"</p>";

--- a/server/static/stylesheets/style.css
+++ b/server/static/stylesheets/style.css
@@ -12,6 +12,16 @@
   color: rgb(140, 140, 10);
 }
 
+.correct {
+	color: green;
+	font-weight: bold;
+}
+
+.incorrect {
+	color: red;
+	font-weight: bold;
+}
+
 #stars {
   margin-top: 10px;
   display: inline-block;


### PR DESCRIPTION
Made some minor style changes that cause the message `"You were correct."` or `"You were incorrect."` to be more apparent by bolding the word correct/incorrect, and highlighting it green if correct and highlighting red if incorrect.
